### PR TITLE
Fix comment form for logged in users

### DIFF
--- a/js/cache-buddy.coffee
+++ b/js/cache-buddy.coffee
@@ -12,13 +12,17 @@ do ($ = jQuery) ->
 	$ ->
 		mustLogIn = $ '.cache-buddy-must-log-in'
 		if readCookie 'cache_buddy_id'
+			formComment = $ '.comment-form-comment'
+				.detach()
 			loggedInMessage = $ '.cache-buddy-logged-in-as'
 				.detach()
 				.show()
 			profileURL = loggedInMessage.data 'profile-url'
-			loggedInMessage.find 'a[href=""]:empty'
+			loggedInMessage.find 'a[href=""]'
 				.html readCookie 'cache_buddy_username'
 				.attr href: profileURL
+			loggedInMessage
+				.append formComment
 			$ '.cache-buddy-comment-fields-wrapper'
 				.html loggedInMessage
 		else if mustLogIn.length


### PR DESCRIPTION
When I tried the plugin running WP 4.4 the comment form did not show and the profile link was not being updated with the JS.

This PR should fix both.

The minified JS file still needs to be generated from the coffeescript.
